### PR TITLE
handle columns that have been prefixed by the table name

### DIFF
--- a/lib/three_stars/builder.rb
+++ b/lib/three_stars/builder.rb
@@ -1,4 +1,3 @@
-
 module ThreeStars
   # generate the recommended index
   class Builder

--- a/lib/three_stars/extensions/active_record.rb
+++ b/lib/three_stars/extensions/active_record.rb
@@ -5,7 +5,7 @@ module ThreeStars
         def to_idx
           ThreeStars::Builder.new(to_sql).call
         rescue Exception => e
-          puts "Unable to lex sql: #{e.message}\nSQL:\n#{to_sql}"
+          puts "Unable to lex sql: #{e.message}\n""SQL:\n#{to_sql}\nBacktrace: #{e.backtrace.join("\n")}"
         end
       end
     end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -46,6 +46,16 @@ describe ThreeStars::Builder do
       end
     end
 
+    context "more complex query" do
+      let(:sql) do
+        %{ SELECT "users".* FROM "users" WHERE "users"."deleted_at" IS NULL AND "users"."name" = 'kyle' }
+      end
+
+      it 'returns an array of the where clauses' do
+        expect(instance.call).to eq 'add_index :users, [:deleted_at, :name]'
+      end
+    end
+
     context 'index name' do
       context 'as an option' do
         let(:options) { { name: 'my_idx' } }

--- a/spec/lexer/where_spec.rb
+++ b/spec/lexer/where_spec.rb
@@ -42,5 +42,12 @@ describe ThreeStars::Lexer do
         expect(subject).to eq(%w(name last_name company))
       end
     end
+
+    context "where using a NULL deleted_at field" do
+      let(:sql) { %{ SELECT "users".* FROM "users" WHERE "users"."deleted_at" IS NULL AND "users"."name" = 'kyle' } }
+      it 'returns an array of the where clauses' do
+        expect(subject).to eq(%w(deleted_at name))
+      end
+    end
   end
 end


### PR DESCRIPTION
adds some lexing around column names like "table".foo  or "table".*
